### PR TITLE
allow namespacing of objects e.g.  o-media

### DIFF
--- a/_objects.media.scss
+++ b/_objects.media.scss
@@ -8,6 +8,7 @@
  */
 
 // Predefine the variables below in order to alter and enable specific features.
+$inuit-object-namespace:            null !default;
 $inuit-media-namespace:             $inuit-namespace !default;
 
 $inuit-media-gutter:                $inuit-base-spacing-unit !default;
@@ -29,8 +30,8 @@ $inuit-media-collapse-at:           720px !default;
 
 
 
-.#{$inuit-media-namespace}media,
-%#{$inuit-media-namespace}media {
+.#{$inuit-object-namespace}#{$inuit-media-namespace}media,
+%#{$inuit-object-namespace}#{$inuit-media-namespace}media {
     @extend %clearfix;
     display: block;
 }


### PR DESCRIPTION
I have added in an optional $inuit-object-namespace variable, the idea is that this can be used to prefix objects with something like 'o-' to easily identify them. Added the extra variable over just using the $inuit-media-namespace as putting the 'o-' in there would result in it being added to all the sub elements and modifiers.

Using the $inuit-object-namespace you can have:

o-media and media__img

Using just the $inuit-media-namespace you would end up with:

o-media and o-media__img

Have done this in forks for a number of the other inuit objects so if you feel it adds value I can create pull requests for them too.
