### PR TITLE
More than one static responsive breakpoint

### DIFF
--- a/_objects.media.scss
+++ b/_objects.media.scss
@@ -23,7 +23,6 @@ $inuit-enable-media--huge:          false !default;
 $inuit-enable-media--rev:           false !default;
 $inuit-enable-media--flush:         false !default;
 $inuit-enable-media--responsive:    false !default;
-$inuit-media-collapse-at:           720px !default;
 
 
 
@@ -268,128 +267,136 @@ $inuit-media-collapse-at:           720px !default;
      *
      * There is a very pragmatic, simple implementation of a responsive media
      * object, which simply places the text-content beneath the image-content.
-     *
-     * We use a `max-width` media query because:
-     *
-     * a) it is the least verbose method in terms of amount of code required.
-     * b) the media object’s default state is image-next-to-text, so its stacked
-     *    state is the exception, rather than the rule.
      */
 
-    @media screen and (max-width: $inuit-media-collapse-at) {
+    @each $breakpoint in $breakpoints {
 
-        .#{$inuit-media-namespace}media--responsive,
-        %#{$inuit-media-namespace}media--responsive {
+        $alias:     nth($breakpoint, 1);
+        $condition: nth($breakpoint, 2);
 
-            /**
-             * Rework the spacings on regular media objects.
-             */
-            > .#{$inuit-media-namespace}media__img,
-            > %#{$inuit-media-namespace}media__img {
-                float: none;
-                margin-right: 0;
-                margin-bottom: $inuit-media-gutter;
-                margin-left:  0;
-            }
+        // This isn’t ideal, but we definitely don’t want to generate
+        // media--responsive for retina devices. Exclude retina
+        // media-qeuries manually.
+        @if ($alias != "retina") {
 
-            @if ($inuit-enable-media--tiny == true) {
+            @include media-query($alias) {
 
-                /**
-                 * Tiny responsive media objects.
-                 *
-                 * Take a little more heavy-handed approach to reworking
-                 * spacings on media objects that are also tiny media objects
-                 * in their regular state.
-                 */
+                .#{$inuit-media-namespace}#{$alias}-media--responsive,
+                %#{$inuit-media-namespace}#{$alias}-media--responsive {
 
-                &.#{$inuit-media-namespace}media--tiny,
-                &%#{$inuit-media-namespace}media--tiny {
-
+                    /**
+                     * Rework the spacings on regular media objects.
+                     */
                     > .#{$inuit-media-namespace}media__img,
                     > %#{$inuit-media-namespace}media__img {
+                        float: none;
                         margin-right: 0;
+                        margin-bottom: $inuit-media-gutter;
                         margin-left:  0;
-                        margin-bottom: $inuit-media-gutter--tiny;
+                    }
+
+                    @if ($inuit-enable-media--tiny == true) {
+
+                        /**
+                         * Tiny responsive media objects.
+                         *
+                         * Take a little more heavy-handed approach to reworking
+                         * spacings on media objects that are also tiny media
+                         * objects in their regular state.
+                         */
+
+                        &.#{$inuit-media-namespace}media--tiny,
+                        &%#{$inuit-media-namespace}media--tiny {
+
+                            > .#{$inuit-media-namespace}media__img,
+                            > %#{$inuit-media-namespace}media__img {
+                                margin-right: 0;
+                                margin-left:  0;
+                                margin-bottom: $inuit-media-gutter--tiny;
+                            }
+
+                        }
+
+                    }
+
+                    @if ($inuit-enable-media--small == true) {
+
+                        /**
+                         * Small responsive media objects.
+                         *
+                         * Take a little more heavy-handed approach to reworking
+                         * spacings on media objects that are also small media
+                         * objects in their regular state.
+                         */
+
+                        &.#{$inuit-media-namespace}media--small,
+                        &%#{$inuit-media-namespace}media--small {
+
+                            > .#{$inuit-media-namespace}media__img,
+                            > %#{$inuit-media-namespace}media__img {
+                                margin-right: 0;
+                                margin-left:  0;
+                                margin-bottom: $inuit-media-gutter--small;
+                            }
+
+                        }
+
+                    }
+
+                    @if ($inuit-enable-media--large == true) {
+
+                        /**
+                         * Large responsive media objects.
+                         *
+                         * Take a little more heavy-handed approach to reworking
+                         * spacings on media objects that are also large media
+                         * objects in their regular state.
+                         */
+
+                        &.#{$inuit-media-namespace}media--large,
+                        &%#{$inuit-media-namespace}media--large {
+
+                            > .#{$inuit-media-namespace}media__img,
+                            > %#{$inuit-media-namespace}media__img {
+                                margin-right: 0;
+                                margin-left:  0;
+                                margin-bottom: $inuit-media-gutter--large;
+                            }
+
+                        }
+
+                    }
+
+                    @if ($inuit-enable-media--huge == true) {
+
+                        /**
+                         * Huge responsive media objects.
+                         *
+                         * Take a little more heavy-handed approach to reworking
+                         * spacings on media objects that are also huge media
+                         * objects in their regular state.
+                         */
+
+                        &.#{$inuit-media-namespace}media--huge,
+                        &%#{$inuit-media-namespace}media--huge {
+
+                            > .#{$inuit-media-namespace}media__img,
+                            > %#{$inuit-media-namespace}media__img {
+                                margin-right: 0;
+                                margin-left:  0;
+                                margin-bottom: $inuit-media-gutter--huge;
+                            }
+
+                        }
+
                     }
 
                 }
 
-            }
+            } // Close media query.
 
-            @if ($inuit-enable-media--small == true) {
+        } // Close retina check.
 
-                /**
-                 * Small responsive media objects.
-                 *
-                 * Take a little more heavy-handed approach to reworking
-                 * spacings on media objects that are also small media objects
-                 * in their regular state.
-                 */
-
-                &.#{$inuit-media-namespace}media--small,
-                &%#{$inuit-media-namespace}media--small {
-
-                    > .#{$inuit-media-namespace}media__img,
-                    > %#{$inuit-media-namespace}media__img {
-                        margin-right: 0;
-                        margin-left:  0;
-                        margin-bottom: $inuit-media-gutter--small;
-                    }
-
-                }
-
-            }
-
-            @if ($inuit-enable-media--large == true) {
-
-                /**
-                 * Large responsive media objects.
-                 *
-                 * Take a little more heavy-handed approach to reworking
-                 * spacings on media objects that are also large media objects
-                 * in their regular state.
-                 */
-
-                &.#{$inuit-media-namespace}media--large,
-                &%#{$inuit-media-namespace}media--large {
-
-                    > .#{$inuit-media-namespace}media__img,
-                    > %#{$inuit-media-namespace}media__img {
-                        margin-right: 0;
-                        margin-left:  0;
-                        margin-bottom: $inuit-media-gutter--large;
-                    }
-
-                }
-
-            }
-
-            @if ($inuit-enable-media--huge == true) {
-
-                /**
-                 * Huge responsive media objects.
-                 *
-                 * Take a little more heavy-handed approach to reworking
-                 * spacings on media objects that are also huge media objects
-                 * in their regular state.
-                 */
-
-                &.#{$inuit-media-namespace}media--huge,
-                &%#{$inuit-media-namespace}media--huge {
-
-                    > .#{$inuit-media-namespace}media__img,
-                    > %#{$inuit-media-namespace}media__img {
-                        margin-right: 0;
-                        margin-left:  0;
-                        margin-bottom: $inuit-media-gutter--huge;
-                    }
-
-                }
-
-            }
-
-        }
-
-    }
+    } // Close breakpoints loop.
 
 }

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,8 @@
   "license": "Apache",
   "dependencies": {
     "inuit-defaults": "~0.2.1",
+    "inuit-responsive-settings": "~0.1.3",
+    "inuit-responsive-tools": "~0.1.3",
     "inuit-clearfix": "~0.2.0",
     "inuit-functions": "~0.2.0"
   }


### PR DESCRIPTION
I've experienced several situations, where just one breakpiont for `media--responsive` isn't enough. Where at one instance of the media object, the `media__body` needs to collapse beneath the `media__img` is at 720px, another instance needs to collapse at 480px (for example).

By iterating over the breakpoints list (as in [trumps.widths-responsive](https://github.com/inuitcss/trumps.widths-responsive) etc.) you are getting more breakpoints, and keeping them dynamic (and syncronized with the othre breakpoints in your project).

One thing I'm uncertain about though is the naming of the responsive modifiers. Should it be `palm-media--responsive` (as it is now), or should it be `media--responsive--palm`?
